### PR TITLE
Update initRuntimes param types

### DIFF
--- a/dist/main.d.ts
+++ b/dist/main.d.ts
@@ -1,4 +1,4 @@
 export { Runtime } from './Runtime';
 export { Module } from './Module';
 export declare let loadedWasm: Promise<null> | null;
-export declare function initRuntimes(initUrl?: string): void;
+export declare function initRuntimes(initUrl?: string | BufferSource): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bridge-js-runtime",
-	"version": "0.3.2",
+	"version": "0.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bridge-js-runtime",
-			"version": "0.3.2",
+			"version": "0.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@swc/wasm-web": "^1.2.218",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bridge-js-runtime",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bridge-js-runtime",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
 				"@swc/wasm-web": "^1.2.218",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bridge-js-runtime",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "A fast compiler for Minecraft Add-Ons",
 	"scripts": {
 		"test": "vitest",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,6 @@ export { Runtime } from './Runtime'
 export { Module } from './Module'
 
 export let loadedWasm: Promise<null> | null = null
-export function initRuntimes(initUrl?: string) {
+export function initRuntimes(initUrl?: string | BufferSource) {
 	loadedWasm = init(initUrl).then(() => null)
 }


### PR DESCRIPTION
Updated the `initRuntimes` function to also accept a `BufferSource` parameter since `@swc/wasm-web`'s `init` function also accepts that.