### PR TITLE
Move node package into the @bridge-editor NPM Org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# bridge-sandbox
+# js-runtime
 Package used by bridge. to execute JavaScript files with ESM syntax

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "bridge-js-runtime",
+	"name": "@bridge-editor/js-runtime",
 	"version": "0.4.2",
-	"lockfileVersion": 2,
+	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "bridge-js-runtime",
+			"name": "@bridge-editor/js-runtime",
 			"version": "0.4.2",
 			"license": "MIT",
 			"dependencies": {
@@ -23,26 +23,39 @@
 				"vite": "^2.6.13"
 			}
 		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"cpu": [
+				"loong64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@swc/wasm": {
 			"version": "1.2.218",
-			"resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.218.tgz",
-			"integrity": "sha512-nPmRkRForZaeoKz2/s16RJdJKaYOVq3RAnVBccDQtaHpeOjZzDga90IMfN0NCOZj/Cjv534ZfjObpT1AzQNJBQ==",
-			"dev": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/wasm-web": {
 			"version": "1.2.218",
-			"resolved": "https://registry.npmjs.org/@swc/wasm-web/-/wasm-web-1.2.218.tgz",
-			"integrity": "sha512-2rRqlsZMzcjKa1cCme3Pjfn9TQXwR+DSHQo9tR3nz8+FORcoqDBue47qllDkHIiCdk3i2oxUv1y3tcXzUg6O1A=="
+			"license": "Apache-2.0"
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
-			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ=="
+			"version": "4.3.16",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
+			"integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ=="
 		},
 		"node_modules/@types/chai-subset": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-			"integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.5.tgz",
+			"integrity": "sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==",
 			"dependencies": {
 				"@types/chai": "*"
 			}
@@ -58,14 +71,17 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-			"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+			"version": "20.12.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+			"integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/path-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/path-browserify/-/path-browserify-1.0.0.tgz",
-			"integrity": "sha512-XMCcyhSvxcch8b7rZAtFAaierBYdeHXVvg2iYnxOV0MCQHmPuRRmGZPFDRzPayxcGiiSL1Te9UIO+f3cuj0tfw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/path-browserify/-/path-browserify-1.0.2.tgz",
+			"integrity": "sha512-ZkC5IUqqIFPXx3ASTTybTzmQdwHwe2C0u3eL75ldQ6T9E9IWFJodn6hIfbZGab73DfyiHN4Xw15gNxUq2FbvBA==",
 			"dev": true
 		},
 		"node_modules/assertion-error": {
@@ -77,26 +93,29 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
 			"dependencies": {
 				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"loupe": "^2.3.1",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
 				"pathval": "^1.1.1",
-				"type-detect": "^4.0.5"
+				"type-detect": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
 			"engines": {
 				"node": "*"
 			}
@@ -118,20 +137,20 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=0.12"
+				"node": ">=6"
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
-			"integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -140,32 +159,33 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"esbuild-android-64": "0.14.47",
-				"esbuild-android-arm64": "0.14.47",
-				"esbuild-darwin-64": "0.14.47",
-				"esbuild-darwin-arm64": "0.14.47",
-				"esbuild-freebsd-64": "0.14.47",
-				"esbuild-freebsd-arm64": "0.14.47",
-				"esbuild-linux-32": "0.14.47",
-				"esbuild-linux-64": "0.14.47",
-				"esbuild-linux-arm": "0.14.47",
-				"esbuild-linux-arm64": "0.14.47",
-				"esbuild-linux-mips64le": "0.14.47",
-				"esbuild-linux-ppc64le": "0.14.47",
-				"esbuild-linux-riscv64": "0.14.47",
-				"esbuild-linux-s390x": "0.14.47",
-				"esbuild-netbsd-64": "0.14.47",
-				"esbuild-openbsd-64": "0.14.47",
-				"esbuild-sunos-64": "0.14.47",
-				"esbuild-windows-32": "0.14.47",
-				"esbuild-windows-64": "0.14.47",
-				"esbuild-windows-arm64": "0.14.47"
+				"@esbuild/linux-loong64": "0.14.54",
+				"esbuild-android-64": "0.14.54",
+				"esbuild-android-arm64": "0.14.54",
+				"esbuild-darwin-64": "0.14.54",
+				"esbuild-darwin-arm64": "0.14.54",
+				"esbuild-freebsd-64": "0.14.54",
+				"esbuild-freebsd-arm64": "0.14.54",
+				"esbuild-linux-32": "0.14.54",
+				"esbuild-linux-64": "0.14.54",
+				"esbuild-linux-arm": "0.14.54",
+				"esbuild-linux-arm64": "0.14.54",
+				"esbuild-linux-mips64le": "0.14.54",
+				"esbuild-linux-ppc64le": "0.14.54",
+				"esbuild-linux-riscv64": "0.14.54",
+				"esbuild-linux-s390x": "0.14.54",
+				"esbuild-netbsd-64": "0.14.54",
+				"esbuild-openbsd-64": "0.14.54",
+				"esbuild-sunos-64": "0.14.54",
+				"esbuild-windows-32": "0.14.54",
+				"esbuild-windows-64": "0.14.54",
+				"esbuild-windows-arm64": "0.14.54"
 			}
 		},
 		"node_modules/esbuild-android-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
-			"integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -178,9 +198,9 @@
 			}
 		},
 		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
-			"integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
 			"cpu": [
 				"arm64"
 			],
@@ -193,9 +213,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
-			"integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
 			"cpu": [
 				"x64"
 			],
@@ -208,9 +228,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
-			"integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
 			"cpu": [
 				"arm64"
 			],
@@ -223,9 +243,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
-			"integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
 			"cpu": [
 				"x64"
 			],
@@ -238,9 +258,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
-			"integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -253,9 +273,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
-			"integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
 			"cpu": [
 				"ia32"
 			],
@@ -268,9 +288,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
-			"integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
 			"cpu": [
 				"x64"
 			],
@@ -283,9 +303,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
-			"integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
 			"cpu": [
 				"arm"
 			],
@@ -298,9 +318,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
-			"integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
 			"cpu": [
 				"arm64"
 			],
@@ -313,9 +333,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
-			"integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -328,9 +348,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
-			"integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -343,9 +363,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
-			"integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -358,9 +378,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
-			"integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
 			"cpu": [
 				"s390x"
 			],
@@ -373,9 +393,9 @@
 			}
 		},
 		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
-			"integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
 			"cpu": [
 				"x64"
 			],
@@ -388,9 +408,9 @@
 			}
 		},
 		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
-			"integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
 			"cpu": [
 				"x64"
 			],
@@ -403,9 +423,9 @@
 			}
 		},
 		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
-			"integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
 			"cpu": [
 				"x64"
 			],
@@ -418,9 +438,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
-			"integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
 			"cpu": [
 				"ia32"
 			],
@@ -433,9 +453,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
-			"integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
 			"cpu": [
 				"x64"
 			],
@@ -448,9 +468,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
-			"integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
 			"cpu": [
 				"arm64"
 			],
@@ -463,9 +483,9 @@
 			}
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"hasInstallScript": true,
 			"optional": true,
 			"os": [
@@ -476,44 +496,47 @@
 			}
 		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"engines": {
 				"node": "*"
 			}
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dependencies": {
-				"function-bind": "^1.1.1"
+				"function-bind": "^1.1.2"
 			},
 			"engines": {
-				"node": ">= 0.4.0"
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -522,9 +545,9 @@
 			}
 		},
 		"node_modules/local-pkg": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.1.tgz",
-			"integrity": "sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
+			"integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
 			"engines": {
 				"node": ">=14"
 			},
@@ -533,17 +556,17 @@
 			}
 		},
 		"node_modules/loupe": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
 			"dependencies": {
-				"get-func-name": "^2.0.0"
+				"get-func-name": "^2.0.1"
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
-			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+			"version": "0.26.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
 			},
@@ -557,9 +580,15 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -586,14 +615,14 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"node_modules/postcss": {
-			"version": "8.4.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -602,23 +631,27 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"source-map-js": "^1.2.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dependencies": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -630,9 +663,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.75.7",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.7.tgz",
-			"integrity": "sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==",
+			"version": "2.77.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -644,9 +677,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -654,7 +687,8 @@
 		"node_modules/sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"deprecated": "Please use @jridgewell/sourcemap-codec instead"
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
@@ -692,9 +726,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -704,15 +738,20 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
 		"node_modules/vite": {
-			"version": "2.9.12",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-			"integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+			"version": "2.9.18",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.18.tgz",
+			"integrity": "sha512-sAOqI5wNM9QvSEE70W3UGMdT8cyEn0+PmJMTFvTB8wB0YbYUWw3gUbY62AOyrXosGieF2htmeLATvNxpv/zNyQ==",
 			"dependencies": {
 				"esbuild": "^0.14.27",
 				"postcss": "^8.4.13",
 				"resolve": "^1.22.0",
-				"rollup": "^2.59.0"
+				"rollup": ">=2.59.0 <2.78.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -783,419 +822,6 @@
 				"jsdom": {
 					"optional": true
 				}
-			}
-		}
-	},
-	"dependencies": {
-		"@swc/wasm": {
-			"version": "1.2.218",
-			"resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.218.tgz",
-			"integrity": "sha512-nPmRkRForZaeoKz2/s16RJdJKaYOVq3RAnVBccDQtaHpeOjZzDga90IMfN0NCOZj/Cjv534ZfjObpT1AzQNJBQ==",
-			"dev": true
-		},
-		"@swc/wasm-web": {
-			"version": "1.2.218",
-			"resolved": "https://registry.npmjs.org/@swc/wasm-web/-/wasm-web-1.2.218.tgz",
-			"integrity": "sha512-2rRqlsZMzcjKa1cCme3Pjfn9TQXwR+DSHQo9tR3nz8+FORcoqDBue47qllDkHIiCdk3i2oxUv1y3tcXzUg6O1A=="
-		},
-		"@types/chai": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
-			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ=="
-		},
-		"@types/chai-subset": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-			"integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
-			"requires": {
-				"@types/chai": "*"
-			}
-		},
-		"@types/json5": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-2.2.0.tgz",
-			"integrity": "sha512-NrVug5woqbvNZ0WX+Gv4R+L4TGddtmFek2u8RtccAgFZWtS9QXF2xCXY22/M4nzkaKF0q9Fc6M/5rxLDhfwc/A==",
-			"dev": true,
-			"requires": {
-				"json5": "*"
-			}
-		},
-		"@types/node": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-			"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
-		},
-		"@types/path-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/path-browserify/-/path-browserify-1.0.0.tgz",
-			"integrity": "sha512-XMCcyhSvxcch8b7rZAtFAaierBYdeHXVvg2iYnxOV0MCQHmPuRRmGZPFDRzPayxcGiiSL1Te9UIO+f3cuj0tfw==",
-			"dev": true
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-		},
-		"chai": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"loupe": "^2.3.1",
-				"pathval": "^1.1.1",
-				"type-detect": "^4.0.5"
-			}
-		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA=="
-		},
-		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"requires": {
-				"ms": "2.1.2"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
-		"esbuild": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
-			"integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
-			"requires": {
-				"esbuild-android-64": "0.14.47",
-				"esbuild-android-arm64": "0.14.47",
-				"esbuild-darwin-64": "0.14.47",
-				"esbuild-darwin-arm64": "0.14.47",
-				"esbuild-freebsd-64": "0.14.47",
-				"esbuild-freebsd-arm64": "0.14.47",
-				"esbuild-linux-32": "0.14.47",
-				"esbuild-linux-64": "0.14.47",
-				"esbuild-linux-arm": "0.14.47",
-				"esbuild-linux-arm64": "0.14.47",
-				"esbuild-linux-mips64le": "0.14.47",
-				"esbuild-linux-ppc64le": "0.14.47",
-				"esbuild-linux-riscv64": "0.14.47",
-				"esbuild-linux-s390x": "0.14.47",
-				"esbuild-netbsd-64": "0.14.47",
-				"esbuild-openbsd-64": "0.14.47",
-				"esbuild-sunos-64": "0.14.47",
-				"esbuild-windows-32": "0.14.47",
-				"esbuild-windows-64": "0.14.47",
-				"esbuild-windows-arm64": "0.14.47"
-			}
-		},
-		"esbuild-android-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
-			"integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
-			"optional": true
-		},
-		"esbuild-android-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
-			"integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
-			"integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
-			"integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
-			"integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
-			"integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
-			"integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
-			"integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
-			"integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
-			"integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
-			"integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
-			"integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
-			"optional": true
-		},
-		"esbuild-linux-riscv64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
-			"integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
-			"optional": true
-		},
-		"esbuild-linux-s390x": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
-			"integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
-			"optional": true
-		},
-		"esbuild-netbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
-			"integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
-			"integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
-			"integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
-			"integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
-			"integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.14.47",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
-			"integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
-			"optional": true
-		},
-		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"optional": true
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig=="
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
-		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
-		},
-		"local-pkg": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.1.tgz",
-			"integrity": "sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw=="
-		},
-		"loupe": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-			"requires": {
-				"get-func-name": "^2.0.0"
-			}
-		},
-		"magic-string": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
-			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
-			"requires": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
-		},
-		"path-browserify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
-		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-		},
-		"pathval": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
-		},
-		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-		},
-		"postcss": {
-			"version": "8.4.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
-			"requires": {
-				"nanoid": "^3.3.4",
-				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
-			}
-		},
-		"resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-			"requires": {
-				"is-core-module": "^2.9.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			}
-		},
-		"rollup": {
-			"version": "2.75.7",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.7.tgz",
-			"integrity": "sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==",
-			"requires": {
-				"fsevents": "~2.3.2"
-			}
-		},
-		"source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
-		},
-		"sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-		},
-		"supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-		},
-		"tinypool": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.1.3.tgz",
-			"integrity": "sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ=="
-		},
-		"tinyspy": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-0.3.3.tgz",
-			"integrity": "sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw=="
-		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-		},
-		"typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true
-		},
-		"vite": {
-			"version": "2.9.12",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-			"integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
-			"requires": {
-				"esbuild": "^0.14.27",
-				"fsevents": "~2.3.2",
-				"postcss": "^8.4.13",
-				"resolve": "^1.22.0",
-				"rollup": "^2.59.0"
-			}
-		},
-		"vitest": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.15.2.tgz",
-			"integrity": "sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==",
-			"requires": {
-				"@types/chai": "^4.3.1",
-				"@types/chai-subset": "^1.3.3",
-				"@types/node": "*",
-				"chai": "^4.3.6",
-				"debug": "^4.3.4",
-				"local-pkg": "^0.4.1",
-				"tinypool": "^0.1.3",
-				"tinyspy": "^0.3.3",
-				"vite": "^2.9.12"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "bridge-js-runtime",
+	"name": "@bridge-editor/js-runtime",
 	"version": "0.4.2",
-	"description": "A fast compiler for Minecraft Add-Ons",
+	"description": "Package used by bridge. to execute JavaScript files with ESM syntax",
 	"scripts": {
 		"test": "vitest",
 		"build:types": "tsc --project tsconfig.json",
@@ -19,14 +19,20 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/bridge-core/bridge-sandbox.git"
+		"url": "git+https://github.com/bridge-core/bridge-js-runtime.git"
 	},
 	"author": "solvedDev",
+	"contributors": [
+		{
+			"name": "Thomas Orsbourne",
+			"email": "thomas@gamemodeone.com"
+		}
+	],
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/bridge-core/bridge-sandbox/issues"
+		"url": "https://github.com/bridge-core/bridge-js-runtime/issues"
 	},
-	"homepage": "https://github.com/bridge-core/bridge-sandbox#readme",
+	"homepage": "https://github.com/bridge-core/bridge-js-runtime#readme",
 	"dependencies": {
 		"@swc/wasm-web": "^1.2.218",
 		"json5": "^2.2.1",


### PR DESCRIPTION
So that we can continue to update this module it has been republished under the @bridge-editor NPM org.

- Renamed module from `bridge-js-runtime` to `@bridge-editor/js-runtime`
- Updated the github links